### PR TITLE
Fix single tag handling in New-ContentPage function

### DIFF
--- a/libs/ZolaContentHelper.psm1
+++ b/libs/ZolaContentHelper.psm1
@@ -97,14 +97,19 @@ thumbnail = "$thumbnail"
 "@
     }
 
-    if ($tags -and $tags.Count -gt 0) {
-        $tagsJson = $tags | ConvertTo-Json -Compress
-        $frontMatter += @"
+    if ($tags) {
+        # Ensure $tags is always treated as an array for consistent JSON output
+        $tagsArray = @($tags)
+        if ($tagsArray.Count -gt 0) {
+            # Force array output even for single elements by using -AsArray parameter
+            $tagsJson = $tagsArray | ConvertTo-Json -Compress -AsArray
+            $frontMatter += @"
 
 [taxonomies]
 tags = $tagsJson
 
 "@
+        }
     }
 
     $frontMatter += @"


### PR DESCRIPTION
- Fixed JSON output consistency for tags in Zola content generation
- Single strings now properly converted to JSON arrays using -AsArray parameter
- Ensures consistent ['tag'] format instead of mixed 'tag' vs ['tag1', 'tag2']
- Wrapped tags in @() array and added proper validation
- All existing tests still pass with improved reliability

🤖 Generated with [Claude Code](https://claude.ai/code)